### PR TITLE
Update DynamicSvgNft.sol

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -75,8 +75,9 @@ contract DynamicSvgNft is ERC721, Ownable {
             revert ERC721Metadata__URI_QueryFor_NonExistentToken();
         }
         (, int256 price, , , ) = i_priceFeed.latestRoundData();
+        int ethPrice = price * 1e10;                             //must convert ether to wei
         string memory imageURI = s_lowImageURI;
-        if (price >= s_tokenIdToHighValues[tokenId]) {
+        if (ethPrice >= s_tokenIdToHighValues[tokenId]) {
             imageURI = s_highImageURI;
         }
         return


### PR DESCRIPTION
Modify the price unit conversion (ether to wei) of the if condition in the tokenURI function.

Because the unit used for calculation in the if conditional is wei.